### PR TITLE
Api updates

### DIFF
--- a/SkyVRaanAutoPatcher/SkyVRaanAutoPatcher.cs
+++ b/SkyVRaanAutoPatcher/SkyVRaanAutoPatcher.cs
@@ -147,7 +147,7 @@ namespace CellEditorIDFixer
                                 var overriddenCell = cellContext.GetOrAddAsOverride(state.PatchMod);
                                 overriddenCell.WaterEnvironmentMap = $"Data\\Textures\\cubemaps\\OutputCube.dds";
 
-                                if (!WaterBlacklist.Contains(overriddenCell.Water.FormKey ?? FormKey.Null))
+                                if (!WaterBlacklist.Contains(overriddenCell.Water.FormKey))
                                 {
                                     overriddenCell.Water = Skyrim.Water.DefaultWater;
                                 }

--- a/SkyVRaanAutoPatcher/SkyVRaanAutoPatcher.csproj
+++ b/SkyVRaanAutoPatcher/SkyVRaanAutoPatcher.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.19.1" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.22.3" />
     <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.10.10" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
FormKeyNullable API changed slightly. Just a PR to adjust to the newer API
`FormKey` is never nullable anymore (so you don't need the `?? FormKey.Null`)
`FormKeyNullable` exists as the alternate if you do care to have that information